### PR TITLE
Added get_API_infos(), comment management and workitem relation retreival

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,3 +336,22 @@ for row in result.rows:
     workitem = client.get_workitem(id)
 ```
 > Note that the query returns a list of work item ids
+## Get infos about API of the server
+You can obtain information about version of API supported by your server for each topic (git, wit, etc):
+```python
+client.get_API_infos('wit')
+```
+It return an array of info about specific API endpoints. For example with workitems comments accessed by revision (this API has been introduced in version 3.0, removed after version 5.0):
+```python
+{
+    'area': 'wit',
+    'id': '19335ae7-22f7-4308-93d8-261f9384b7cf',
+    'maxVersion': '5.0',
+    'minVersion': '3.0',
+    'releasedVersion': '0.0',
+    'resourceName': 'comments',
+    'resourceVersion': 2,
+    'routeTemplate': '{project}/_apis/{area}/workItems/{id}/comments/{revision}'
+}
+```
+Please see [this Github issue from MicrosoftDocs/vsts-docs](https://github.com/MicrosoftDocs/vsts-docs/issues/1567) for detailed explanation about this version API.

--- a/README.md
+++ b/README.md
@@ -288,6 +288,36 @@ for team in client.get_teams(project_name)['value']:
 	for dev in client.get_team_members(project_name, team['id'])['value']:
 		print(dev['identity']['displayName']] + ': ' + dev['identity']['uniqueName'])
 ```
+## Managing comments of workitems
+### Get all comments of a workitem
+```python
+from vstsclient.vstsclient import VstsClient
+
+client = VstsClient('dev.azure.com/<account>', '<personalaccesstoken>')
+comments = client.get_comments_from_workitem('project', 73)
+```
+### Get specific comment of a workitem
+Comments inside a workitem are indexed by comment id.
+```python
+from vstsclient.vstsclient import VstsClient
+
+client = VstsClient('dev.azure.com/<account>', '<personalaccesstoken>')
+comment = client.get_comment_from_workitem('project', 73, 8307896)
+```
+### Add a comment of a workitem
+```python
+from vstsclient.vstsclient import VstsClient
+
+client = VstsClient('dev.azure.com/<account>', '<personalaccesstoken>')
+comment = client.create_comment('project', 73, 'This is a test comment!')
+```
+### Removing a comment of a workitem
+```python
+from vstsclient.vstsclient import VstsClient
+
+client = VstsClient('dev.azure.com/<account>', '<personalaccesstoken>')
+client.delete_comment('project', 73, 8307896)
+```
 ## Fields
 ### Create a field
 Create a new field.
@@ -341,7 +371,7 @@ You can obtain information about version of API supported by your server for eac
 ```python
 client.get_API_infos('wit')
 ```
-It return an array of info about specific API endpoints. For example with workitems comments accessed by revision (this API has been introduced in version 3.0, removed after version 5.0):
+It return an array of info about specific API endpoints. For example with workitems comments accessed by revision (this API has):
 ```python
 {
     'area': 'wit',

--- a/vstsclient/_deserialize.py
+++ b/vstsclient/_deserialize.py
@@ -62,7 +62,7 @@ def _parse_json_to_workitems(response):
     return workitems
 
 def _parse_json_to_workitem(response):
-    attrs = ['id', 'rev', 'fields', 'url']
+    attrs = ['id', 'rev', 'fields', 'url', 'relations']
     return _map_attrs_values(Workitem, attrs, response)
 
 def _parse_json_to_iteration(response):

--- a/vstsclient/vstsclient.py
+++ b/vstsclient/vstsclient.py
@@ -333,6 +333,58 @@ class VstsClient(object):
         request.headers = {'content-type': 'application/json-patch+json'}
         self._perform_request(request)
 
+    # GET {account}.visualstudio.com/{collection}/_apis/wit/workitems/{workitem_id}/comments
+    def get_comments_from_workitem(self, project, workitem_id):
+        _validate_not_none('project', project)
+        _validate_not_none('workitem_id', workitem_id)
+
+        request = HTTPRequest()
+        request.method  = 'GET'
+        request.path    = '/{}/_apis/wit/workitems/{}/comments'.format(project, workitem_id)
+        request.query   = 'api-version=5.1-preview.3&$expand=all'
+        request.headers = {'content-type': 'application/json'}
+        return self._perform_request(request)
+    
+    # GET {account}.visualstudio.com/{collection}/{project}/_apis/wit/workitems/{workitem_id}/comments/{comment_id}
+    def get_comment_from_workitem(self, project, workitem_id, comment_id):
+        _validate_not_none('project', project)
+        _validate_not_none('workitem_id', workitem_id)
+        _validate_not_none('comment_id', comment_id)
+
+        request = HTTPRequest()
+        request.method  = 'GET'
+        request.path    = '/{}/_apis/wit/workitems/{}/comments/{}'.format(project, workitem_id, comment_id)
+        request.query   = 'api-version=5.1-preview.3&$expand=all'
+        request.headers = {'content-type': 'application/json'}
+        return self._perform_request(request)
+
+    # POST {account}.visualstudio.com/{collection}/{project_name}/_apis/wit/workitems/{workitem_id}/comments
+    def create_comment(self, project_name, workitem_id, text, bypass_rules=False):
+        _validate_not_none('project_name', project_name)
+        _validate_not_none('workitem_id', workitem_id)
+        _validate_not_none('text', text)
+        
+        request = HTTPRequest()
+        request.method  = 'POST'
+        request.path    = '/{}/_apis/wit/workitems/{}/comments'.format(project_name, workitem_id)
+        request.query   = 'api-version=5.1-preview.3&bypassRules={}'.format(bypass_rules)
+        request.body    = json.dumps({'text': text})
+        request.headers = {'content-type': 'application/json'}
+        return self._perform_request(request)
+
+    # DELETE {account}.visualstudio.com/{collection}/{project_name}/_apis/wit/workitems/{workitem_id}/comments/{comment_revision}
+    def delete_comment(self, project_name, workitem_id, comment_revision):
+        _validate_not_none('project_name', project_name)
+        _validate_not_none('workitem_id', workitem_id)
+        _validate_not_none('comment_revision', comment_revision)
+
+        request = HTTPRequest()
+        request.method  = 'DELETE'
+        request.path    = '/{}/_apis/wit/workitems/{}/comments/{}'.format(project_name, workitem_id, comment_revision)
+        request.query   = 'api-version=5.1-preview.3'
+        request.headers = {'content-type': 'application/json'}
+        self._perform_request(request)
+
     def add_tags(self, workitem_id: int, tags: list):
         _validate_not_none('workitem_id', workitem_id)
         _validate_not_none('tags', tags)
@@ -565,6 +617,9 @@ class VstsClient(object):
 
         if response.status >= 300:
             raise HTTPError(response.status, response.message, response.headers, response.body)
+
+        if response.body == b'':
+            return None
 
         result = json.loads(response.body.decode('UTF-8'))
 

--- a/vstsclient/vstsclient.py
+++ b/vstsclient/vstsclient.py
@@ -68,6 +68,15 @@ class VstsClient(object):
         _validate_not_none('host', host)
         self._http_client.set_proxy(host, port, user, password)
 
+    # OPTIONS {account}.visualstudio.com/{collection}/_apis/{}
+    def get_API_infos(self, item):
+        request = HTTPRequest()
+        request.method  = 'OPTIONS'
+        request.path    = '/_apis/{}'.format(item)
+        request.query   = ''
+        request.headers = {'content-type': 'application/json'}
+        return self._perform_request(request)
+
     # GET {account}.visualstudio.com/{collection}/_apis/projects
     def get_projects(self, state='WellFormed', top=100, skip=0):
         request = HTTPRequest()


### PR DESCRIPTION
Hi,
This fct allows to retrieve info from server regarding API and version supported. This is useful when developing to know what are is the API range to be used (for example, comment access by revision has been introduced in version 3.0, removed after version 5.0 and does not support updating or deleting comment; after version 5.0, comment are accessed by ID and can be updating and removed). This could be useful, in the future, to choose, at runtime, between different possible API endpoint, the best one available on the server.
Regards,
Colin
PS.: I'm still working on comment management.